### PR TITLE
update Docker port usage to 3333

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test.watch": "stencil test --spec --e2e --watchAll",
     "generate": "stencil generate",
     "docker:build": " docker build -t getting-started .",
-    "docker:start": "docker run -dp 3000:3000 getting-started"
+    "docker:start": "docker run -dp 3333:3333 getting-started"
   },
   "dependencies": {
     "@stencil/core": "^2.0.1"


### PR DESCRIPTION
Changes:
- update port exposed to 3333, which is the default that Stencil uses

Ideally, I want to point the team to this reproduction case to verify a set of changes I'm going to propose to fix https://github.com/ionic-team/stencil/issues/2930, and if they could use it without changing the port setup that'd be great! Or, if there's an alternative way to run this without changing the port mapping, that's equally great 🙂  LMK and I'll close this PR if that's the case